### PR TITLE
Use relative paths for installing valetudo

### DIFF
--- a/fwinstaller_1t/install-val.sh
+++ b/fwinstaller_1t/install-val.sh
@@ -56,10 +56,10 @@ if [[ -f ./boot.img ]]; then
 			
 			killall valetudo
 			rm /data/valetudo
-			cp /tmp/valetudo /data/valetudo
+			cp ./valetudo /data/valetudo
 			chmod +x /data/valetudo
 			
-			cp _root_postboot.sh.tpl /data/_root_postboot.sh
+			cp ./_root_postboot.sh.tpl /data/_root_postboot.sh
 			chmod +x /data/_root_postboot.sh
 			
 			echo "Valetudo installation finished, continue FW update"


### PR DESCRIPTION
I noticed that valetudo is not copied when extracting the generated firmware somewhere other than /tmp (I created a subfolder in /tmp ...)